### PR TITLE
Refactor/disconnected component check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,11 +21,11 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "spatial_proteomics"
-copyright = "2022, Harald Vohringer, Matthias Meyer-Bender"
+copyright = "2024, Harald Vohringer, Matthias Meyer-Bender"
 author = "Harald Vohringer, Matthias Meyer-Bender"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = "0.4.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -5,5 +5,5 @@ The external (:code:`ext`) accessor
 
 The external accessor contains methods that utilise third-party tools to enable operations such as segmentation or cell type prediction.
 
-.. automodule:: spatial_proteomics.ext.external
+.. automodule:: spatialproteomics.ext.external
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Spatial-data documentation master file, created by
+.. Spatialproteomics documentation master file, created by
    sphinx-quickstart on Tue Aug 16 14:14:34 2022.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to the documentation of spatial_proteomics!
+Welcome to the documentation of spatialproteomics!
 =======================================
 
 

--- a/docs/label.rst
+++ b/docs/label.rst
@@ -6,5 +6,5 @@ The label (:code:`la`) accessor
 
 The label accessor provides several functions associated with cell type annotations and gating.
 
-.. automodule:: spatial_proteomics.la.label
+.. automodule:: spatialproteomics.la.label
    :members:

--- a/docs/plot.rst
+++ b/docs/plot.rst
@@ -6,5 +6,5 @@ The plot (:code:`pl`) accessor
 
 The plotting accessor provides several plotting functions.
 
-.. automodule:: spatial_proteomics.pl.plot
+.. automodule:: spatialproteomics.pl.plot
    :members:

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -6,5 +6,5 @@ The preprocessing (:code:`pp`) accessor
 
 The preprocessing accessor provides several to subset image data.
 
-.. automodule:: spatial_proteomics.pp.preprocessing
+.. automodule:: spatialproteomics.pp.preprocessing
    :members:

--- a/spatialproteomics/ext/external.py
+++ b/spatialproteomics/ext/external.py
@@ -27,7 +27,7 @@ class ExternalAccessor:
         gpu: bool = True,
         model_type: str = "cyto3",
         return_xarray: bool = True,
-        handle_disconnected: str = "keep_largest",
+        handle_disconnected: str = "ignore",
     ):
         """
         Segment cells using Cellpose.
@@ -220,7 +220,7 @@ class ExternalAccessor:
         normalize: bool = True,
         nuclear_channel: str = "DAPI",
         predict_big: bool = False,
-        handle_disconnected: str = "keep_largest",
+        handle_disconnected: str = "ignore",
         **kwargs,
     ) -> xr.Dataset:
         """

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -236,7 +236,7 @@ class PreprocessingAccessor:
         mask_growth: int = 0,
         relabel: bool = True,
         copy: bool = True,
-        handle_disconnected: str = "keep_largest",
+        handle_disconnected: str = "ignore",
     ) -> xr.Dataset:
         """
         Adds a segmentation mask (_segmentation) field to the xarray dataset.
@@ -882,7 +882,7 @@ class PreprocessingAccessor:
         # adding the new filtered and relabeled segmentation
         return xr.merge([obj, da])
 
-    def grow_cells(self, iterations: int = 2, handle_disconnected: str = "keep_largest"):
+    def grow_cells(self, iterations: int = 2, handle_disconnected: str = "ignore"):
         """
         Grows the cells in the segmentation mask.
         """

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -15,6 +15,7 @@ from ..constants import COLORS, Dims, Features, Labels, Layers, Props
 from ..la.utils import _format_labels
 from .intensity import sum_intensity
 from .utils import (
+    _get_disconnected_cell,
     _merge_segmentation,
     _normalize,
     _relabel_cells,
@@ -1060,3 +1061,6 @@ class PreprocessingAccessor:
             df[Features.LABELS] = df[Features.LABELS].apply(lambda x: label_dict[x])
 
         return df
+
+    def get_disconnected_cell(self):
+        return _get_disconnected_cell(self._obj[Layers.SEGMENTATION])

--- a/spatialproteomics/pp/utils.py
+++ b/spatialproteomics/pp/utils.py
@@ -184,9 +184,13 @@ def _check_for_disconnected_cells(segmentation: np.ndarray, handle: str = "error
         return False
     else:
         if handle == "error":
-            raise ValueError("Found disconnected masks in the segmentation.")
+            raise ValueError(
+                "Found disconnected masks in the segmentation. Use pp.get_disconnected_cell() to see which cell is disconnected."
+            )
         elif handle == "warning":
-            logger.warning("Found disconnected masks in the segmentation.")
+            logger.warning(
+                "Found disconnected masks in the segmentation. Use pp.get_disconnected_cell() to see which cell is disconnected."
+            )
         return True
 
 
@@ -253,3 +257,11 @@ def handle_disconnected_cells(segmentation: np.ndarray, mode: str = "ignore"):
         logger.warning("Relabeled all cells to avoid disconnected cells.")
 
     return segmentation
+
+
+def _get_disconnected_cell(segmentation):
+    for cell in sorted(np.unique(segmentation))[1:]:
+        binary_mask = np.where(segmentation == cell, 1, 0)
+        _, num_features = scipy.ndimage.label(binary_mask)
+        if num_features != 1:
+            return cell

--- a/tests/pp/test_handle_disconnected_cells.py
+++ b/tests/pp/test_handle_disconnected_cells.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from spatialproteomics.pp.utils import handle_disconnected_cells
+from spatialproteomics.pp.utils import _get_disconnected_cell, handle_disconnected_cells
 
 
 def test_handle_disconnected_cells():
@@ -54,3 +54,17 @@ def test_handle_disconnected_cells_relabel():
     arr_target = np.array([[0, 0, 0, 1, 0], [0, 3, 0, 2, 0], [0, 3, 0, 2, 0], [0, 0, 0, 0, 0]])
 
     assert np.all(arr_processed == arr_target), f"Processed array: {arr_processed}"
+
+
+def test_get_disconnected_cell():
+    arr = np.array([[0, 0, 0, 0, 0], [0, 1, 0, 2, 0], [0, 1, 0, 2, 0], [0, 0, 0, 0, 0]])
+
+    # should not flag anything
+    disconnected_cell = _get_disconnected_cell(arr)
+    assert disconnected_cell is None
+
+    arr = np.array([[0, 0, 0, 1, 0], [0, 1, 0, 2, 0], [0, 1, 0, 2, 0], [0, 0, 0, 0, 0]])
+
+    # should flag 1
+    disconnected_cell = _get_disconnected_cell(arr)
+    assert disconnected_cell == 1


### PR DESCRIPTION
Major speed improvement in checking for disconnected components.
Switched default behavior to ignore disconnected cells, now only a warning is thrown.
Added function to find disconnected cells, enabling further investigations in case disconnected components are found.