### PR TITLE
Feature/render multiple segmentations

### DIFF
--- a/spatialproteomics/constants.py
+++ b/spatialproteomics/constants.py
@@ -50,6 +50,7 @@ class Dims(object):
 
 class Attrs(object):
     IMAGE_COLORS = "image_colors"
+    SEGMENTATION_COLORS = "segmentation_colors"
     LABEL_COLORS = "label_colors"
     LABEL_NAMES = "label_names"
 

--- a/spatialproteomics/pl/plot.py
+++ b/spatialproteomics/pl/plot.py
@@ -374,7 +374,29 @@ class PlotAccessor:
     def render_segmentation(
         self,
         layer_key: str = Layers.SEGMENTATION,
-        colors: List[str] = ["white"],
+        colors: List[str] = [
+            "white",
+            "#e6194B",
+            "#3cb44b",
+            "#ffe119",
+            "#4363d8",
+            "#f58231",
+            "#911eb4",
+            "#42d4f4",
+            "#f032e6",
+            "#bfef45",
+            "#fabed4",
+            "#469990",
+            "#dcbeff",
+            "#9A6324",
+            "#fffac8",
+            "#800000",
+            "#aaffc3",
+            "#808000",
+            "#ffd8b1",
+            "#000075",
+            "#a9a9a9",
+        ],
         alpha: float = 0.0,
         alpha_boundary: float = 1.0,
         mode: str = "inner",
@@ -416,8 +438,10 @@ class PlotAccessor:
 
         # checking that there are as many colors as there are channels in the segmentation mask which is rendered
         assert (
-            len(colors) == segmentation.shape[0]
-        ), f"Number of colors ({len(colors)}) does not match the number of channels in the segmentation mask ({segmentation.shape[0]}). Please specify a color for each segmentation channel using the colors keyword."
+            len(colors) >= segmentation.shape[0]
+        ), f"Trying to render {segmentation.shape[0]} segmentation layers. Please provide custom colors using the colors argument."
+
+        colors = colors[: len(channels)]
 
         if Layers.PLOT in self._obj:
             attrs = self._obj[Layers.PLOT].attrs
@@ -608,7 +632,7 @@ class PlotAccessor:
         if legend_label:
             legend += self._obj.pl._create_label_legend()
 
-        if legend_image or legend_label:
+        if legend_image or legend_segmentation or legend_label:
             ax.legend(handles=legend, **legend_kwargs)
 
         return self._obj

--- a/spatialproteomics/pl/plot.py
+++ b/spatialproteomics/pl/plot.py
@@ -340,6 +340,7 @@ class PlotAccessor:
 
     def render_segmentation(
         self,
+        layer_key: str = Layers.SEGMENTATION,
         alpha: float = 0.0,
         alpha_boundary: float = 1.0,
         mode: str = "inner",
@@ -348,6 +349,7 @@ class PlotAccessor:
         Renders the segmentation mask with optional alpha blending and boundary rendering.
 
         Parameters:
+            layer_key (str, optional): The key of the layer containing the segmentation mask. Default is Layers.SEGMENTATION.
             alpha (float, optional): The alpha value for blending the segmentation mask with the plot. Default is 0.0.
             alpha_boundary (float, optional): The alpha value for rendering the boundary of the segmentation mask. Default is 1.0.
             mode (str, optional): The mode for rendering the segmentation mask. Possible values are "inner" and "outer". Default is "inner".
@@ -364,12 +366,12 @@ class PlotAccessor:
             - The rendered segmentation mask will be added as a new layer to the object.
         """
         assert (
-            Layers.SEGMENTATION in self._obj
-        ), "No segmentation layer found. Please add a segmentation mask before calling this method."
+            layer_key in self._obj
+        ), f"Could not find segmentation layer with key {layer_key}. Please add a segmentation mask before calling this method."
 
         color_dict = {1: "white"}
         cmap = _get_listed_colormap(color_dict)
-        segmentation = self._obj[Layers.SEGMENTATION].values
+        segmentation = self._obj[layer_key].values
 
         if Layers.PLOT in self._obj:
             attrs = self._obj[Layers.PLOT].attrs

--- a/spatialproteomics/pl/utils.py
+++ b/spatialproteomics/pl/utils.py
@@ -108,21 +108,21 @@ def _render_segmentation(
     mode: str = "inner",
 ) -> np.ndarray:
     """
-    Rendering a (potentially 3D) segmentation mask.
+    Render a 2D or 3D (in the case of multiple segmentations, e. g. with cellpose) segmentation.
 
     Parameters:
-        img (np.ndarray): The input image to be colorized.
-        colors (List[str], optional): The list of colors to be used for colorization. Defaults to ["C1", "C2", "C3", "C4", "C5"].
+        segmentation (np.ndarray): The segmentation array with shape (num_channels, height, width).
+        colors (List[str]): The list of colors to be applied to each channel of the segmentation.
         background (str, optional): The background color. Defaults to "black".
-        normalize (bool, optional): Whether to normalize the image before colorization. Defaults to True.
+        img (np.ndarray, optional): The image to be used as a base for rendering. Defaults to None.
+        alpha (float, optional): The transparency level for the colored segmentation. Defaults to 0.2.
+        alpha_boundary (float, optional): The transparency level for the boundary of the segmentation. Defaults to 1.0.
+        mode (str, optional): The mode for finding boundaries. Defaults to "inner".
 
     Returns:
-        np.ndarray: The colorized image.
+        np.ndarray: The rendered image with shape (num_channels, height, width, rgba).
 
-    Raises:
-        AssertionError: If the length of the palette is less than the number of channels in the image.
     """
-    # TODO: FIX DOCS FOR THIS METHOD
     num_channels = segmentation.shape[0]
     cmaps = _get_linear_colormap(colors[:num_channels], background)
     # transforming the segmentation into dtype float (otherwise it is not rendered for some reason)
@@ -140,8 +140,9 @@ def _render_segmentation(
         img[..., -1] = 1
 
     # if a plot is already provided, we need to copy it n_marker times to apply the masking operations later
+    # intensities are normalized by n_channels to avoid overexposure
     if len(img.shape) == 3:
-        img = np.repeat(img[np.newaxis, :, :, :], num_channels, axis=0)
+        img = np.repeat(img[np.newaxis, :, :, :], num_channels, axis=0) / num_channels
 
     im = img.copy()
 

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -323,7 +323,9 @@ class PreprocessingAccessor:
             The amended image container.
         """
         if layer_key not in self._obj:
-            raise ValueError(f"No segmentation mask found at layer {layer_key}.")
+            raise ValueError(
+                f"No segmentation mask found at layer {layer_key}. You can specify which layer to use with the layer_key parameter."
+            )
 
         if type(properties) is str:
             properties = [properties]
@@ -909,7 +911,7 @@ class PreprocessingAccessor:
 
         assert (
             segmentation_key in self._obj
-        ), f"Segmentation mask with key {segmentation_key} not found in the object. Set segmentation_key to ensure that the segmentation masks are synchronized to the observations."
+        ), f"Segmentation mask with key {segmentation_key} not found in the object. You can specify the key with the segmentation_key parameter."
 
         cells = self._obj[Layers.OBS].sel({Dims.FEATURES: col}).values.copy()
         cells_bool = func(cells)


### PR DESCRIPTION
Adressed #33

Segmentation masks can now be rendered from layers other than the default `_segmentation` layer like this:

```
# syntax for specifying a segmentation mask to render
# img_merged was segmented with cellpose, and the segmentation was stored in "_segmentation_cellpose"
fig, ax = plt.subplots(1, 2, figsize=(20, 10))

# explicit syntax with render_segmentation and imshow
_ = (img_cellpose.pp[["DAPI", "CD11c", "CD68"]]
                 .pl.colorize(["gray", "purple", "orange"])
                 .pl.render_segmentation(layer_key='_segmentation_cellpose')
                 .pl.imshow(ax=ax[0]))
# implicit syntax with show
_ = (img_cellpose.pp[["DAPI", "CD11c", "CD68"]]
                 .pl.colorize(["gray", "purple", "orange"])
                 .pl.show(render_segmentation=True, segmentation_kwargs={'layer_key': '_segmentation_cellpose'}, ax=ax[1]))
```

This code creates the following plot.
![image](https://github.com/sagar87/spatialproteomics/assets/62450528/80bd20a9-34f7-4f06-a31c-6ab69934fa93)

Multiple segmentation masks can be rendered in different colors.
```
# syntax for rendering multiple segmentation masks
# img_merged was segmented with cellpose, and the segmentation was stored in _segmentation_cellpose
fig, ax = plt.subplots(1, 5, figsize=(50, 10))

# intensity image, just for comparison
_ = (img_merged.pp[["DAPI", "CD21"]]
               .pl.colorize(["gray", "purple"])
               .pl.show(ax=ax[0]))
# explicit syntax using render_segmentation and imshow
_ = (img_merged.pp[["DAPI", "CD21"]]
               .pl.colorize(["gray", "purple"])
               .pl.render_segmentation(layer_key='_segmentation_cellpose', colors=['white', 'red'])
               .pl.imshow(ax=ax[1]))
_ = (img_merged.pp[["DAPI", "CD21"]]
               .pl.colorize(["gray", "purple"])
               .pl.render_segmentation(layer_key='_segmentation_cellpose', colors=['white', 'red'])
               .pl.imshow(legend_image=True, ax=ax[2]))
_ = (img_merged.pp[["DAPI", "CD21"]]
               .pl.colorize(["gray", "purple"])
               .pl.render_segmentation(layer_key='_segmentation_cellpose', colors=['white', 'red'])
               .pl.imshow(legend_image=True, legend_segmentation=True, ax=ax[3]))
# implicit syntax using show
_ = (img_merged.pp[["DAPI", "CD21"]]
               .pl.colorize(["gray", "purple"])
               .pl.show(render_segmentation=True, segmentation_kwargs={'layer_key': '_segmentation_cellpose', 'colors': ['white', 'red']}, ax=ax[4]))
```
This creates the following plot.
![image](https://github.com/sagar87/spatialproteomics/assets/62450528/923f1b2f-bf25-4d30-8bea-842876122820)
