### PR TITLE
Refactor/add labels

### DIFF
--- a/spatialproteomics/container.py
+++ b/spatialproteomics/container.py
@@ -62,7 +62,7 @@ def load_image_data(
         dataset = dataset.pp.add_segmentation(segmentation)
 
         if labels is not None:
-            dataset = dataset.pp.add_labels(labels, cell_col=cell_col, label_col=label_col)
+            dataset = dataset.pp.add_labels_from_dataframe(labels, cell_col=cell_col, label_col=label_col)
 
     else:
         dataset = xr.Dataset(data_vars={Layers.IMAGE: im})

--- a/spatialproteomics/la/label.py
+++ b/spatialproteomics/la/label.py
@@ -636,7 +636,7 @@ class LabelAccessor:
             obj = obj.pp.drop_layers(Layers.PROPERTIES)
 
         # adding the new labels
-        return obj.pp.add_labels(celltype_prediction_df)
+        return obj.pp.add_labels_from_dataframe(celltype_prediction_df)
 
     def _threshold_label(
         self, channel: str, threshold: float, layer_key: str = Layers.INTENSITY, label: Optional[str] = None

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -588,7 +588,7 @@ class PreprocessingAccessor:
 
         return xr.merge([da, self._obj])
 
-    def add_labels(
+    def add_labels_from_dataframe(
         self,
         df: Union[pd.DataFrame, None] = None,
         cell_col: str = "cell",
@@ -868,12 +868,9 @@ class PreprocessingAccessor:
 
         Raises:
         - AssertionError: If no image layer is found in the object.
-        - AssertionError: If no segmentation mask is found in the object.
         """
         # checking if the object contains an image layer
         assert Layers.IMAGE in self._obj, "No image layer found in the object."
-        # checking if the object contains a segmentation mask
-        assert Layers.SEGMENTATION in self._obj, "No segmentation mask found in the object."
 
         image_layer = self._obj[Layers.IMAGE]
 
@@ -885,15 +882,20 @@ class PreprocessingAccessor:
         obj = self._obj.drop(Layers.IMAGE)
 
         if Layers.SEGMENTATION in self._obj:
+            # if a segmentation mask is present in the object
             seg_layer = self._obj[Layers.SEGMENTATION]
             new_seg = xr.DataArray(
                 seg_layer.values[::rate, ::rate], coords=[y, x], dims=[Dims.Y, Dims.X], name=Layers.SEGMENTATION
             )
             obj = obj.drop(Layers.SEGMENTATION)
 
-        obj = obj.drop_dims([Dims.Y, Dims.X])
+            obj = obj.drop_dims([Dims.Y, Dims.X])
 
-        return xr.merge([obj, new_img, new_seg])
+            return xr.merge([obj, new_img, new_seg])
+        else:
+            # if no segmentation is present in the object
+            obj = obj.drop_dims([Dims.Y, Dims.X])
+            return xr.merge([obj, new_img])
 
     def rescale(self, scale: int):
         """

--- a/spatialproteomics/tl/tool.py
+++ b/spatialproteomics/tl/tool.py
@@ -385,7 +385,9 @@ class ToolAccessor:
         assigned_cell_types[cell_id_col] = assigned_cell_types[cell_id_col].astype(int)
 
         # adding the labels to the xarray object
-        return self._obj.pp.add_labels(assigned_cell_types, cell_col=cell_id_col, label_col=cell_type_col)
+        return self._obj.pp.add_labels_from_dataframe(
+            assigned_cell_types, cell_col=cell_id_col, label_col=cell_type_col
+        )
 
     def convert_to_anndata(
         self,

--- a/tests/la/test_predict_cell_types_argmax.py
+++ b/tests/la/test_predict_cell_types_argmax.py
@@ -36,7 +36,7 @@ def test_predict_cell_types_argmax_without_overwriting_existing_annotations(data
     )
 
     # adding the labels
-    ds = dataset_full.pp.add_labels(df)
+    ds = dataset_full.pp.add_labels_from_dataframe(df)
 
     # adding a quantification layer
     ds = ds.pp.add_quantification()

--- a/tests/pp/test_add_labels.py
+++ b/tests/pp/test_add_labels.py
@@ -42,3 +42,18 @@ def test_add_labels_from_dataframe_unassigned_cells(dataset):
     assert Features.LABELS in labeled[Layers.OBS].coords[Dims.FEATURES].values
     assert 0 in labeled[Layers.OBS].sel(features=Features.LABELS).values
     assert 1 in labeled[Layers.OBS].sel(features=Features.LABELS).values
+
+
+def test_add_labels(dataset):
+    # creating a dummy dict
+    cells = dataset.coords[Dims.CELLS].values
+    num_cells = len(cells)
+    label_dict = dict(zip(cells, ["CT1"] * num_cells))
+
+    # adding the labels
+    labeled = dataset.pp.add_labels(label_dict)
+
+    # checking that the labels were added
+    assert Dims.LABELS in labeled.coords
+    assert Features.LABELS in labeled[Layers.OBS].coords[Dims.FEATURES].values
+    assert 1 in labeled[Layers.OBS].sel(features=Features.LABELS).values

--- a/tests/pp/test_add_labels.py
+++ b/tests/pp/test_add_labels.py
@@ -3,7 +3,7 @@ import pandas as pd
 from spatialproteomics.constants import Dims, Features, Labels, Layers
 
 
-def test_add_labels_correct_annotation(dataset):
+def test_add_labels_from_dataframe_correct_annotation(dataset):
     # creating a dummy data frame
     cells = dataset.coords[Dims.CELLS].values
     num_cells = len(cells)
@@ -15,7 +15,7 @@ def test_add_labels_correct_annotation(dataset):
     )
 
     # adding the labels
-    labeled = dataset.pp.add_labels(df)
+    labeled = dataset.pp.add_labels_from_dataframe(df)
 
     # checking that the labels were added
     assert Dims.LABELS in labeled.coords
@@ -23,7 +23,7 @@ def test_add_labels_correct_annotation(dataset):
     assert 1 in labeled[Layers.OBS].sel(features=Features.LABELS).values
 
 
-def test_add_labels_unassigned_cells(dataset):
+def test_add_labels_from_dataframe_unassigned_cells(dataset):
     # creating a dummy data frame
     cells = dataset.coords[Dims.CELLS].values
     num_cells = len(cells)
@@ -35,7 +35,7 @@ def test_add_labels_unassigned_cells(dataset):
     )
 
     # adding the labels
-    labeled = dataset.pp.add_labels(df)
+    labeled = dataset.pp.add_labels_from_dataframe(df)
 
     # checking that the labels were added
     assert Dims.LABELS in labeled.coords

--- a/tests/pp/test_add_segmentation.py
+++ b/tests/pp/test_add_segmentation.py
@@ -46,12 +46,12 @@ def test_add_segmentation_negative_values(data_dic, dataset_segmentation):
         dataset_segmentation.pp.add_segmentation(corrupted_segmentation)
 
 
-def test_add_segmentation_relabel(data_dic, dataset_segmentation):
+def test_add_segmentation_reindex(data_dic, dataset_segmentation):
     noncontinuous_segmentation = data_dic["segmentation"]
     noncontinuous_segmentation[10, 10] = np.max(noncontinuous_segmentation) + 2
     num_cells = len(np.unique(noncontinuous_segmentation)) - 1  # -1 because of the background
 
-    segmented = dataset_segmentation.pp.add_segmentation(noncontinuous_segmentation, relabel=True)
+    segmented = dataset_segmentation.pp.add_segmentation(noncontinuous_segmentation, reindex=True)
     cell_labels = sorted(np.unique(segmented["_segmentation"].values))[1:]  # removing the background
 
     assert cell_labels == list(range(1, num_cells + 1))


### PR DESCRIPTION
Addressed #40.

Added `pp.add_labels`, which simply adds labels from a mapping instead of a data frame. The previous implementation of `pp.add_labels` has been renamed to `pp.add_labels_from_dataframe`. Useful when trying to get labels from a merged cellpose segmentation into the object like this:

![image](https://github.com/sagar87/spatialproteomics/assets/62450528/a67c192b-9474-46b0-ae4d-1c1dcd858be7)
