### PR TITLE
Feature/mesmer

### DIFF
--- a/spatialproteomics/tl/tool.py
+++ b/spatialproteomics/tl/tool.py
@@ -275,10 +275,10 @@ class ToolAccessor:
         image = self._obj.pp[channels][Layers.IMAGE].values
         # mesmer requires the data to be in shape batch_size (1), x, y, channels (2)
         image = np.expand_dims(np.transpose(image, (1, 2, 0)), 0)
-        
+
         all_masks = app.predict(image, **kwargs)
         all_masks = postprocess_func(all_masks)
-        
+
         da = _convert_masks_to_data_array(self._obj, all_masks, key_added)
 
         return xr.merge([self._obj, da])

--- a/spatialproteomics/tl/utils.py
+++ b/spatialproteomics/tl/utils.py
@@ -1,0 +1,44 @@
+import numpy as np
+import xarray as xr
+
+from ..constants import Dims, Layers
+
+
+def _get_channels(obj, key_added, channel):
+    if key_added in obj:
+        raise KeyError(f'The key "{key_added}" already exists. Please choose another key.')
+
+    if key_added == Layers.SEGMENTATION:
+        raise KeyError(f'The key "{Layers.SEGMENTATION}" is reserved, use pp.add_segmentation if necessary.')
+
+    if channel is not None:
+        channels = [channel]
+    else:
+        channels = obj.coords[Dims.CHANNELS].values.tolist()
+
+    return channels
+
+
+def _convert_masks_to_data_array(obj, all_masks, key_added):
+    # if there is one channel, we can squeeze the mask tensor
+    if len(all_masks) == 1:
+        da = xr.DataArray(
+            all_masks[0].squeeze(),
+            coords=[obj.coords[Dims.Y], obj.coords[Dims.X]],
+            dims=[Dims.Y, Dims.X],
+            name=key_added,
+        )
+    # if we segment on all of the channels, we need to add the channel dimension
+    else:
+        da = xr.DataArray(
+            np.stack(all_masks, 0),
+            coords=[
+                obj.coords[Dims.CHANNELS],
+                obj.coords[Dims.Y],
+                obj.coords[Dims.X],
+            ],
+            dims=[Dims.CHANNELS, Dims.Y, Dims.X],
+            name=key_added,
+        )
+
+    return da


### PR DESCRIPTION
Implemented mesmer. Note that Mesmer by default expects both a nuclear and a membrane marker, even if you ask it to only predict nuclei. Hence there is no `channel` argument in Mesmer, as it assumes there to be one nuclear and one membrane stain.

![image](https://github.com/sagar87/spatialproteomics/assets/62450528/180e17f3-208b-42d9-b612-0da88b69ad62)