### PR TITLE
Feature/optional reindexing of cells

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ copyright = "2024, Matthias Meyer-Bender, Harald Vohringer"
 author = "Matthias Meyer-Bender, Harald Vohringer"
 
 # Dynamically set the release version for multi-version builds
-release = os.getenv("SPHINX_MULTIVERSION_NAME", "0.7.10")
+release = os.getenv("SPHINX_MULTIVERSION_NAME", "0.8.0")
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spatialproteomics"
-version = "0.7.10"
+version = "0.8.0"
 description = "Spatialproteomics is an interoperable toolbox for analyzing highly multiplexed fluorescence image data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -313,6 +313,7 @@ def filter_by_obs(
     func: Callable,
     segmentation_key: str = SDLayers.SEGMENTATION,
     table_key: str = SDLayers.TABLE,
+    reindex: bool = True,
     copy: bool = False,
 ):
     """
@@ -324,6 +325,7 @@ def filter_by_obs(
         func (Callable): A filtering function that takes in the values of the feature and returns a boolean array.
         segmentation_key (str): The key of the segmentation mask in the object. Default is SDLayers.SEGMENTATION.
         table_key (str): The key of the table in the object. Default is SDLayers.TABLE.
+        reindex (bool): Whether to reindex the obs after filtering. Default is True.
         copy (bool): If True, a copy of the object is returned. Default is False.
     """
     import spatialdata
@@ -347,13 +349,15 @@ def filter_by_obs(
     # setting all cells that are not in cells to 0
     segmentation = _remove_unlabeled_cells(segmentation, cells_sel)
     # relabeling cells in the segmentation mask so the IDs go from 1 to n again
-    segmentation, relabel_dict = _relabel_cells(segmentation)
+    if reindex:
+        segmentation, relabel_dict = _relabel_cells(segmentation)
 
     # removing the cells which are not in cells_sel
     adata = adata[adata.obs[SDFeatures.ID].isin(cells_sel), :].copy()
     # updating the cell coords of the object
-    adata.obs[SDFeatures.ID] = [relabel_dict[cell] for cell in adata.obs[SDFeatures.ID].values]
-    adata.obs.index = [f"Cell_{x}" for x in adata.obs[SDFeatures.ID].values]
+    if reindex:
+        adata.obs[SDFeatures.ID] = [relabel_dict[cell] for cell in adata.obs[SDFeatures.ID].values]
+        adata.obs.index = [f"Cell_{x}" for x in adata.obs[SDFeatures.ID].values]
 
     # overwriting the segmentation mask in the object
     # get transformations

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -313,7 +313,7 @@ def filter_by_obs(
     func: Callable,
     segmentation_key: str = SDLayers.SEGMENTATION,
     table_key: str = SDLayers.TABLE,
-    reindex: bool = True,
+    reindex: bool = False,
     copy: bool = False,
 ):
     """
@@ -325,7 +325,7 @@ def filter_by_obs(
         func (Callable): A filtering function that takes in the values of the feature and returns a boolean array.
         segmentation_key (str): The key of the segmentation mask in the object. Default is SDLayers.SEGMENTATION.
         table_key (str): The key of the table in the object. Default is SDLayers.TABLE.
-        reindex (bool): Whether to reindex the obs after filtering. Default is True.
+        reindex (bool): Whether to reindex the obs after filtering. Default is False.
         copy (bool): If True, a copy of the object is returned. Default is False.
     """
     import spatialdata
@@ -826,7 +826,7 @@ class PreprocessingAccessor:
     def add_segmentation(
         self,
         segmentation: Union[str, np.ndarray] = None,
-        reindex: bool = True,
+        reindex: bool = False,
         keep_labels: bool = True,
         add_obs: bool = True,
     ) -> xr.Dataset:
@@ -1598,7 +1598,7 @@ class PreprocessingAccessor:
         return xr.merge([obj, new_img, new_seg], join="outer", compat="no_conflicts")
 
     def filter_by_obs(
-        self, col: str, func: Callable, segmentation_key: str = Layers.SEGMENTATION, reindex: bool = True
+        self, col: str, func: Callable, segmentation_key: str = Layers.SEGMENTATION, reindex: bool = False
     ):
         """
         Filter the object by observations based on a given feature and filtering function.
@@ -1607,7 +1607,7 @@ class PreprocessingAccessor:
             col (str): The name of the feature to filter by.
             func (Callable): A filtering function that takes in the values of the feature and returns a boolean array.
             segmentation_key (str): The key of the segmentation mask in the object. Default is Layers.SEGMENTATION.
-            reindex (bool): Whether to reindex the cell IDs after filtering. Default is True.
+            reindex (bool): Whether to reindex the cell IDs after filtering. Default is False.
 
         Returns:
             xr.Dataset: The filtered object with the selected cells and updated segmentation mask.
@@ -1670,7 +1670,7 @@ class PreprocessingAccessor:
         dilation_size: int = 25,
         threshold: int = 5,
         segmentation_key: str = Layers.SEGMENTATION,
-        reindex: bool = True,
+        reindex: bool = False,
     ):
         """
         Removes outlying cells from the image container. It does so by dilating the segmentation mask and removing cells that belong to a connected component with less than 'threshold' cells.
@@ -1684,7 +1684,7 @@ class PreprocessingAccessor:
         segmentation_key : str
             The key of the segmentation mask in the object. Default is '_segmentation'.
         reindex : bool
-            Whether to reindex the cell IDs after filtering. Default is True.
+            Whether to reindex the cell IDs after filtering. Default is False.
 
         Returns
         -------
@@ -2097,7 +2097,7 @@ class PreprocessingAccessor:
         return xr.merge([obj, da], join="outer", compat="no_conflicts")
 
     def mask_cells(
-        self, mask_key: str = Layers.MASK, segmentation_key=Layers.SEGMENTATION, reindex: bool = True
+        self, mask_key: str = Layers.MASK, segmentation_key=Layers.SEGMENTATION, reindex: bool = False
     ) -> xr.Dataset:
         """
         Mask cells in the segmentation mask.
@@ -2105,7 +2105,7 @@ class PreprocessingAccessor:
         Parameters:
             mask_key (str): The key of the mask to use for masking.
             segmentation_key (str): The key of the segmentation mask in the object. Default is Layers.SEGMENTATION.
-            reindex (bool): Whether to reindex the cell IDs after filtering. Default is True.
+            reindex (bool): Whether to reindex the cell IDs after filtering. Default is False.
 
         Returns:
             xr.Dataset: The object with the masked cells in the segmentation mask.

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -1597,7 +1597,9 @@ class PreprocessingAccessor:
 
         return xr.merge([obj, new_img, new_seg], join="outer", compat="no_conflicts")
 
-    def filter_by_obs(self, col: str, func: Callable, segmentation_key: str = Layers.SEGMENTATION):
+    def filter_by_obs(
+        self, col: str, func: Callable, segmentation_key: str = Layers.SEGMENTATION, reindex: bool = True
+    ):
         """
         Filter the object by observations based on a given feature and filtering function.
 
@@ -1605,6 +1607,7 @@ class PreprocessingAccessor:
             col (str): The name of the feature to filter by.
             func (Callable): A filtering function that takes in the values of the feature and returns a boolean array.
             segmentation_key (str): The key of the segmentation mask in the object. Default is Layers.SEGMENTATION.
+            reindex (bool): Whether to reindex the cell IDs after filtering. Default is True.
 
         Returns:
             xr.Dataset: The filtered object with the selected cells and updated segmentation mask.
@@ -1614,7 +1617,6 @@ class PreprocessingAccessor:
 
         Notes:
             - This method filters the object by selecting only the cells that satisfy the filtering condition.
-            - It also updates the segmentation mask to remove cells that are not selected and relabels the remaining cells.
 
         Example:
             To filter the object by the feature "area" and keep only the cells with an area greater than 70px:
@@ -1643,10 +1645,11 @@ class PreprocessingAccessor:
         segmentation = obj[segmentation_key].values
         # setting all cells that are not in cells to 0
         segmentation = _remove_unlabeled_cells(segmentation, cells_sel)
-        # relabeling cells in the segmentation mask so the IDs go from 1 to n again
-        segmentation, relabel_dict = _relabel_cells(segmentation)
-        # updating the cell coords of the object
-        obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords[Dims.CELLS].values]
+        if reindex:
+            # relabeling cells in the segmentation mask so the IDs go from 1 to n again
+            segmentation, relabel_dict = _relabel_cells(segmentation)
+            # updating the cell coords of the object
+            obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords[Dims.CELLS].values]
 
         # creating a data array with the segmentation mask, so that we can merge it to the original
         da = xr.DataArray(
@@ -1663,7 +1666,11 @@ class PreprocessingAccessor:
         return xr.merge([obj, da], join="outer", compat="no_conflicts")
 
     def remove_outlying_cells(
-        self, dilation_size: int = 25, threshold: int = 5, segmentation_key: str = Layers.SEGMENTATION
+        self,
+        dilation_size: int = 25,
+        threshold: int = 5,
+        segmentation_key: str = Layers.SEGMENTATION,
+        reindex: bool = True,
     ):
         """
         Removes outlying cells from the image container. It does so by dilating the segmentation mask and removing cells that belong to a connected component with less than 'threshold' cells.
@@ -1676,6 +1683,8 @@ class PreprocessingAccessor:
             The minimum number of cells in a connected component required for the cells to be kept. Default is 5.
         segmentation_key : str
             The key of the segmentation mask in the object. Default is '_segmentation'.
+        reindex : bool
+            Whether to reindex the cell IDs after filtering. Default is True.
 
         Returns
         -------
@@ -1707,10 +1716,11 @@ class PreprocessingAccessor:
         obj = self._obj.sel(query)
         # setting all cells that are not in cells to 0
         segmentation = _remove_unlabeled_cells(segmentation, cells_sel)
-        # relabeling cells in the segmentation mask so the IDs go from 1 to n again
-        segmentation, relabel_dict = _relabel_cells(segmentation)
-        # updating the cell coords of the object
-        obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords[Dims.CELLS].values]
+        if reindex:
+            # relabeling cells in the segmentation mask so the IDs go from 1 to n again
+            segmentation, relabel_dict = _relabel_cells(segmentation)
+            # updating the cell coords of the object
+            obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords[Dims.CELLS].values]
 
         # creating a data array with the segmentation mask, so that we can merge it to the original
         da = xr.DataArray(
@@ -2086,13 +2096,16 @@ class PreprocessingAccessor:
 
         return xr.merge([obj, da], join="outer", compat="no_conflicts")
 
-    def mask_cells(self, mask_key: str = Layers.MASK, segmentation_key=Layers.SEGMENTATION) -> xr.Dataset:
+    def mask_cells(
+        self, mask_key: str = Layers.MASK, segmentation_key=Layers.SEGMENTATION, reindex: bool = True
+    ) -> xr.Dataset:
         """
         Mask cells in the segmentation mask.
 
         Parameters:
             mask_key (str): The key of the mask to use for masking.
             segmentation_key (str): The key of the segmentation mask in the object. Default is Layers.SEGMENTATION.
+            reindex (bool): Whether to reindex the cell IDs after filtering. Default is True.
 
         Returns:
             xr.Dataset: The object with the masked cells in the segmentation mask.
@@ -2121,10 +2134,11 @@ class PreprocessingAccessor:
         segmentation = obj[segmentation_key].values
         # setting all cells that are not in cells to 0
         segmentation = _remove_unlabeled_cells(segmentation, cells_sel)
-        # relabeling cells in the segmentation mask so the IDs go from 1 to n again
-        segmentation, relabel_dict = _relabel_cells(segmentation)
-        # updating the cell coords of the object
-        obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords["cells"].values]
+        if reindex:
+            # relabeling cells in the segmentation mask so the IDs go from 1 to n again
+            segmentation, relabel_dict = _relabel_cells(segmentation)
+            # updating the cell coords of the object
+            obj.coords[Dims.CELLS] = [relabel_dict[cell] for cell in obj.coords["cells"].values]
 
         # creating a data array with the segmentation mask, so that we can merge it to the original
         da = xr.DataArray(

--- a/tests/pp/test_filter_by_obs.py
+++ b/tests/pp/test_filter_by_obs.py
@@ -14,6 +14,30 @@ def test_filter_by_obs(ds_segmentation):
 
     # coords are synchronized with the segmentation mask
     assert filtered.sizes[Dims.CELLS] == len(np.unique(filtered[Layers.SEGMENTATION].values)) - 1
+    cell_ids_in_coords = set(filtered.coords[Dims.CELLS].values)
+    cell_ids_in_segmentation = set(np.unique(filtered[Layers.SEGMENTATION].values)) - {0}
+    assert cell_ids_in_coords == cell_ids_in_segmentation
+
+
+def test_filter_by_obs_no_reindex(ds_segmentation):
+    filtered = ds_segmentation.pp.add_observations("area").pp.filter_by_obs(
+        "area", func=lambda x: (x > 50) & (x < 100), reindex=False
+    )
+
+    # obs are retained after filtering
+    assert Layers.OBS in filtered
+    # size is smaller than before filtering
+    assert len(filtered[Layers.OBS]) < len(ds_segmentation[Layers.OBS])
+
+    # coords are synchronized with the segmentation mask
+    assert filtered.sizes[Dims.CELLS] == len(np.unique(filtered[Layers.SEGMENTATION].values)) - 1
+    cell_ids_in_coords = set(filtered.coords[Dims.CELLS].values)
+    cell_ids_in_segmentation = set(np.unique(filtered[Layers.SEGMENTATION].values)) - {0}
+    assert cell_ids_in_coords == cell_ids_in_segmentation
+    # cell IDs are not changed when reindex is False
+    assert set(filtered[Layers.OBS][Dims.CELLS].values).issubset(set(ds_segmentation[Layers.OBS][Dims.CELLS].values))
+    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
+    assert 1 not in set(filtered[Layers.OBS][Dims.CELLS].values)
 
 
 def test_filter_by_obs_no_change(ds_segmentation):

--- a/tests/pp/test_filter_by_obs.py
+++ b/tests/pp/test_filter_by_obs.py
@@ -17,11 +17,15 @@ def test_filter_by_obs(ds_segmentation):
     cell_ids_in_coords = set(filtered.coords[Dims.CELLS].values)
     cell_ids_in_segmentation = set(np.unique(filtered[Layers.SEGMENTATION].values)) - {0}
     assert cell_ids_in_coords == cell_ids_in_segmentation
+    # cell IDs are not changed when reindex is False
+    assert set(filtered[Layers.OBS][Dims.CELLS].values).issubset(set(ds_segmentation[Layers.OBS][Dims.CELLS].values))
+    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
+    assert 1 not in set(filtered[Layers.OBS][Dims.CELLS].values)
 
 
-def test_filter_by_obs_no_reindex(ds_segmentation):
+def test_filter_by_obs_reindex(ds_segmentation):
     filtered = ds_segmentation.pp.add_observations("area").pp.filter_by_obs(
-        "area", func=lambda x: (x > 50) & (x < 100), reindex=False
+        "area", func=lambda x: (x > 50) & (x < 100), reindex=True
     )
 
     # obs are retained after filtering
@@ -34,10 +38,6 @@ def test_filter_by_obs_no_reindex(ds_segmentation):
     cell_ids_in_coords = set(filtered.coords[Dims.CELLS].values)
     cell_ids_in_segmentation = set(np.unique(filtered[Layers.SEGMENTATION].values)) - {0}
     assert cell_ids_in_coords == cell_ids_in_segmentation
-    # cell IDs are not changed when reindex is False
-    assert set(filtered[Layers.OBS][Dims.CELLS].values).issubset(set(ds_segmentation[Layers.OBS][Dims.CELLS].values))
-    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
-    assert 1 not in set(filtered[Layers.OBS][Dims.CELLS].values)
 
 
 def test_filter_by_obs_no_change(ds_segmentation):

--- a/tests/pp/test_mask_cells.py
+++ b/tests/pp/test_mask_cells.py
@@ -3,10 +3,6 @@ import pytest
 
 from spatialproteomics.constants import Dims, Layers
 
-# test that there are less cells after
-# test that cells are labeled consecutively
-# test that the mask is binary
-
 
 def test_mask_cells(ds_segmentation):
     # x and y shape of the dataset
@@ -20,26 +16,26 @@ def test_mask_cells(ds_segmentation):
     # check that there are less cells after masking
     assert len(ds.coords[Dims.CELLS]) < len(ds_segmentation.coords[Dims.CELLS])
 
-    # check that cells are labeled consecutively
-    assert np.all(np.diff(ds.coords[Dims.CELLS]) == 1)
+    # check that cell IDs are not changed when reindex is False
+    cells_before = set(ds_segmentation.coords[Dims.CELLS].values)
+    cells_after = set(ds.coords[Dims.CELLS].values)
+    assert cells_after.issubset(cells_before)
 
 
-def test_mask_cells_reindex_false(ds_segmentation):
+def test_mask_cells_reindex(ds_segmentation):
     # x and y shape of the dataset
     x, y = ds_segmentation.sizes[Dims.X], ds_segmentation.sizes[Dims.Y]
     # creating a dummy mask
     labels = np.ones((x, y))
     labels[0:50, 0:50] = 0
 
-    ds = ds_segmentation.pp.add_layer(labels).pp.mask_cells(reindex=False)
+    ds = ds_segmentation.pp.add_layer(labels).pp.mask_cells(reindex=True)
 
     # check that there are less cells after masking
     assert len(ds.coords[Dims.CELLS]) < len(ds_segmentation.coords[Dims.CELLS])
 
-    # check that cell IDs are not changed when reindex is False
-    cells_before = set(ds_segmentation.coords[Dims.CELLS].values)
-    cells_after = set(ds.coords[Dims.CELLS].values)
-    assert cells_after.issubset(cells_before)
+    # check that cells are labeled consecutively
+    assert np.all(np.diff(ds.coords[Dims.CELLS]) == 1)
 
 
 def test_mask_cells_no_segmentation(ds_image):

--- a/tests/pp/test_mask_cells.py
+++ b/tests/pp/test_mask_cells.py
@@ -24,6 +24,24 @@ def test_mask_cells(ds_segmentation):
     assert np.all(np.diff(ds.coords[Dims.CELLS]) == 1)
 
 
+def test_mask_cells_reindex_false(ds_segmentation):
+    # x and y shape of the dataset
+    x, y = ds_segmentation.sizes[Dims.X], ds_segmentation.sizes[Dims.Y]
+    # creating a dummy mask
+    labels = np.ones((x, y))
+    labels[0:50, 0:50] = 0
+
+    ds = ds_segmentation.pp.add_layer(labels).pp.mask_cells(reindex=False)
+
+    # check that there are less cells after masking
+    assert len(ds.coords[Dims.CELLS]) < len(ds_segmentation.coords[Dims.CELLS])
+
+    # check that cell IDs are not changed when reindex is False
+    cells_before = set(ds_segmentation.coords[Dims.CELLS].values)
+    cells_after = set(ds.coords[Dims.CELLS].values)
+    assert cells_after.issubset(cells_before)
+
+
 def test_mask_cells_no_segmentation(ds_image):
     # x and y shape of the dataset
     x, y = ds_image.sizes[Dims.X], ds_image.sizes[Dims.Y]

--- a/tests/pp/test_remove_outlying_cells.py
+++ b/tests/pp/test_remove_outlying_cells.py
@@ -9,21 +9,21 @@ def test_remove_outlying_cells(ds_segmentation):
     ds_filtered = ds_segmentation.pp.remove_outlying_cells()
     num_cells_segmentation_filtered = np.unique(ds_filtered[Layers.SEGMENTATION].values).shape[0] - 1
     assert num_cells_segmentation_filtered <= num_cells_segmentation
-    # check that cell IDs are changed when reindex is True (the default)
-    assert set(np.unique(ds_filtered[Layers.SEGMENTATION].values)) - {0} == set(
-        range(1, num_cells_segmentation_filtered + 1)
-    )
-
-
-def test_remove_outlying_cells_no_reindex(ds_segmentation):
-    num_cells_segmentation = np.unique(ds_segmentation[Layers.SEGMENTATION].values).shape[0] - 1
-    ds_filtered = ds_segmentation.pp.remove_outlying_cells(reindex=False)
-    num_cells_segmentation_filtered = np.unique(ds_filtered[Layers.SEGMENTATION].values).shape[0] - 1
-    assert num_cells_segmentation_filtered <= num_cells_segmentation
     # check that cell IDs are not changed when reindex is False
     assert set(np.unique(ds_filtered[Layers.SEGMENTATION].values)) - {0} == set(
         np.unique(ds_segmentation[Layers.SEGMENTATION].values)
     ) - {0}
+
+
+def test_remove_outlying_cells_reindex(ds_segmentation):
+    num_cells_segmentation = np.unique(ds_segmentation[Layers.SEGMENTATION].values).shape[0] - 1
+    ds_filtered = ds_segmentation.pp.remove_outlying_cells(reindex=True)
+    num_cells_segmentation_filtered = np.unique(ds_filtered[Layers.SEGMENTATION].values).shape[0] - 1
+    assert num_cells_segmentation_filtered <= num_cells_segmentation
+    # check that cell IDs are changed when reindex is True
+    assert set(np.unique(ds_filtered[Layers.SEGMENTATION].values)) - {0} == set(
+        range(1, num_cells_segmentation_filtered + 1)
+    )
 
 
 def test_remove_outlying_cells_wrong_threshold(ds_segmentation):

--- a/tests/pp/test_remove_outlying_cells.py
+++ b/tests/pp/test_remove_outlying_cells.py
@@ -9,6 +9,21 @@ def test_remove_outlying_cells(ds_segmentation):
     ds_filtered = ds_segmentation.pp.remove_outlying_cells()
     num_cells_segmentation_filtered = np.unique(ds_filtered[Layers.SEGMENTATION].values).shape[0] - 1
     assert num_cells_segmentation_filtered <= num_cells_segmentation
+    # check that cell IDs are changed when reindex is True (the default)
+    assert set(np.unique(ds_filtered[Layers.SEGMENTATION].values)) - {0} == set(
+        range(1, num_cells_segmentation_filtered + 1)
+    )
+
+
+def test_remove_outlying_cells_no_reindex(ds_segmentation):
+    num_cells_segmentation = np.unique(ds_segmentation[Layers.SEGMENTATION].values).shape[0] - 1
+    ds_filtered = ds_segmentation.pp.remove_outlying_cells(reindex=False)
+    num_cells_segmentation_filtered = np.unique(ds_filtered[Layers.SEGMENTATION].values).shape[0] - 1
+    assert num_cells_segmentation_filtered <= num_cells_segmentation
+    # check that cell IDs are not changed when reindex is False
+    assert set(np.unique(ds_filtered[Layers.SEGMENTATION].values)) - {0} == set(
+        np.unique(ds_segmentation[Layers.SEGMENTATION].values)
+    ) - {0}
 
 
 def test_remove_outlying_cells_wrong_threshold(ds_segmentation):

--- a/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
+++ b/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
@@ -19,13 +19,20 @@ def test_filter_by_obs(ds_labels_spatialdata):
     cell_ids_in_obs = set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
     cell_ids_in_obs_names = set([int(name.replace("Cell_", "")) for name in ds.tables[SDLayers.TABLE].obs_names])
     cell_ids_in_segmentation = set(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - {0}
-    assert cell_ids_in_obs_names == cell_ids_in_segmentation
     assert cell_ids_in_obs == cell_ids_in_segmentation
+    assert cell_ids_in_obs_names == cell_ids_in_segmentation
+
+    # cell IDs are not changed when reindex is False
+    assert set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values).issubset(
+        set(ds_labels_spatialdata.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
+    )
+    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
+    assert 1 not in set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
 
 
-def test_filter_by_obs_no_reindex(ds_labels_spatialdata):
+def test_filter_by_obs_reindex(ds_labels_spatialdata):
     ds = sp.pp.add_observations(ds_labels_spatialdata, "area", copy=True)
-    sp.pp.filter_by_obs(ds, "area", func=lambda x: (x > 50) & (x < 100), reindex=False)
+    sp.pp.filter_by_obs(ds, "area", func=lambda x: (x > 50) & (x < 100), reindex=True)
 
     # table is retained after filtering
     assert SDLayers.TABLE in ds.tables.keys()
@@ -37,15 +44,8 @@ def test_filter_by_obs_no_reindex(ds_labels_spatialdata):
     cell_ids_in_obs = set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
     cell_ids_in_obs_names = set([int(name.replace("Cell_", "")) for name in ds.tables[SDLayers.TABLE].obs_names])
     cell_ids_in_segmentation = set(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - {0}
-    assert cell_ids_in_obs == cell_ids_in_segmentation
     assert cell_ids_in_obs_names == cell_ids_in_segmentation
-
-    # cell IDs are not changed when reindex is False
-    assert set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values).issubset(
-        set(ds_labels_spatialdata.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
-    )
-    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
-    assert 1 not in set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
+    assert cell_ids_in_obs == cell_ids_in_segmentation
 
 
 def test_filter_by_obs_no_change(ds_labels_spatialdata):

--- a/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
+++ b/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
@@ -16,6 +16,11 @@ def test_filter_by_obs(ds_labels_spatialdata):
 
     # coords are synchronized with the segmentation mask
     assert ds.tables[SDLayers.TABLE].obs.shape[0] == len(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - 1
+    cell_ids_in_obs = set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
+    cell_ids_in_obs_names = set([int(name.replace("Cell_", "")) for name in ds.tables[SDLayers.TABLE].obs_names])
+    cell_ids_in_segmentation = set(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - {0}
+    assert cell_ids_in_obs_names == cell_ids_in_segmentation
+    assert cell_ids_in_obs == cell_ids_in_segmentation
 
 
 def test_filter_by_obs_no_reindex(ds_labels_spatialdata):
@@ -29,6 +34,11 @@ def test_filter_by_obs_no_reindex(ds_labels_spatialdata):
 
     # coords are synchronized with the segmentation mask
     assert ds.tables[SDLayers.TABLE].obs.shape[0] == len(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - 1
+    cell_ids_in_obs = set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
+    cell_ids_in_obs_names = set([int(name.replace("Cell_", "")) for name in ds.tables[SDLayers.TABLE].obs_names])
+    cell_ids_in_segmentation = set(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - {0}
+    assert cell_ids_in_obs == cell_ids_in_segmentation
+    assert cell_ids_in_obs_names == cell_ids_in_segmentation
 
     # cell IDs are not changed when reindex is False
     assert set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values).issubset(

--- a/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
+++ b/tests/spatialdata_backend/pp/test_filter_by_obs_spatialdata.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import spatialproteomics as sp
-from spatialproteomics.constants import SDLayers
+from spatialproteomics.constants import SDFeatures, SDLayers
 
 
 def test_filter_by_obs(ds_labels_spatialdata):
@@ -16,6 +16,26 @@ def test_filter_by_obs(ds_labels_spatialdata):
 
     # coords are synchronized with the segmentation mask
     assert ds.tables[SDLayers.TABLE].obs.shape[0] == len(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - 1
+
+
+def test_filter_by_obs_no_reindex(ds_labels_spatialdata):
+    ds = sp.pp.add_observations(ds_labels_spatialdata, "area", copy=True)
+    sp.pp.filter_by_obs(ds, "area", func=lambda x: (x > 50) & (x < 100), reindex=False)
+
+    # table is retained after filtering
+    assert SDLayers.TABLE in ds.tables.keys()
+    # size is smaller than before filtering
+    assert ds.tables[SDLayers.TABLE].obs.shape[0] < ds_labels_spatialdata.tables[SDLayers.TABLE].obs.shape[0]
+
+    # coords are synchronized with the segmentation mask
+    assert ds.tables[SDLayers.TABLE].obs.shape[0] == len(np.unique(ds.labels[SDLayers.SEGMENTATION].values)) - 1
+
+    # cell IDs are not changed when reindex is False
+    assert set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values).issubset(
+        set(ds_labels_spatialdata.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
+    )
+    # cell IDs do not start at 1 when reindex is False (they technically could, but not in this example dataset)
+    assert 1 not in set(ds.tables[SDLayers.TABLE].obs[SDFeatures.ID].values)
 
 
 def test_filter_by_obs_no_change(ds_labels_spatialdata):

--- a/uv.lock
+++ b/uv.lock
@@ -5929,7 +5929,7 @@ wheels = [
 
 [[package]]
 name = "spatialproteomics"
-version = "0.7.10"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
By default, reindexing is now set to False, so that cell IDs are kept consistent even when filtering.