### PR TITLE
Add anndata obsm export

### DIFF
--- a/spatialproteomics/container.py
+++ b/spatialproteomics/container.py
@@ -106,9 +106,6 @@ def load_image_data(
             if neighborhood is not None:
                 dataset = dataset.nh.add_neighborhoods_from_dataframe(neighborhood, neighborhood_col=neighborhood_col)
 
-    else:
-        dataset = xr.Dataset(data_vars={Layers.IMAGE: im})
-
     return dataset
 
 

--- a/spatialproteomics/pp/preprocessing.py
+++ b/spatialproteomics/pp/preprocessing.py
@@ -866,7 +866,7 @@ class PreprocessingAccessor:
             from_layer = segmentation
             segmentation = self._obj[segmentation].values.squeeze()
 
-        assert segmentation.ndim == 2, "A segmentation mask must 2 dimensional."
+        assert segmentation.ndim == 2, "A segmentation mask must be 2-dimensional."
         assert ~np.any(segmentation < 0), "A segmentation mask may not contain negative numbers."
 
         y_dim, x_dim = segmentation.shape
@@ -939,14 +939,14 @@ class PreprocessingAccessor:
         """
         # checking that the layer does not exist yet
         assert key_added not in self._obj, f"Layer {key_added} already exists."
-        assert array.ndim in [2, 3], "The array to add mask must 2 or 3-dimensional."
+        assert array.ndim in [2, 3], "The array to add mask must be 2- or 3-dimensional."
 
         if array.ndim == 2:
             # in the case of a 2D array
             y_dim, x_dim = array.shape
             assert (x_dim == self._obj.sizes[Dims.X]) & (
                 y_dim == self._obj.sizes[Dims.Y]
-            ), f"The shape of array does not match that of the image. Image has shape ({self._obj.sizes[Dims.Y]}, {self._obj.sizes[Dims.X]}), array has shape {array.shape}."
+            ), f"The shape of the array does not match that of the image. Image has shape ({self._obj.sizes[Dims.Y]}, {self._obj.sizes[Dims.X]}), array has shape {array.shape}."
 
             # create a data array with the new layer
             da = xr.DataArray(

--- a/spatialproteomics/tl/tool.py
+++ b/spatialproteomics/tl/tool.py
@@ -588,6 +588,7 @@ class ToolAccessor:
         expression_matrix_key: str = Layers.INTENSITY,
         obs_key: str = Layers.OBS,
         additional_layers: Optional[dict] = None,
+        additional_obsm: Optional[dict] = None,
         additional_uns: Optional[dict] = None,
     ):
         """
@@ -601,6 +602,8 @@ class ToolAccessor:
             The key of the observation data in the spatialproteomics object. Default is '_obs'.
         additional_layers : dict, optional
             Additional layers to include in the anndata.AnnData object. The keys are the names of the layers and the values are the corresponding keys in the spatialproteomics object.
+        additional_obsm : dict, optional
+            Additional obsm data to include in the anndata.AnnData object. The keys are the names of the obsm data and the values are the corresponding keys in the spatialproteomics object.
         additional_uns : dict, optional
             Additional uns data to include in the anndata.AnnData object. The keys are the names of the uns data and the values are the corresponding keys in the spatialproteomics object.
 
@@ -612,7 +615,7 @@ class ToolAccessor:
         Raises
         ------
         AssertionError
-            If the expression matrix key or additional layers are not found in the spatialproteomics object.
+            If additional layers, obsm entries, or uns entries are not found in the spatialproteomics object, or if additional layers or obsm entries have incompatible shapes.
 
         Notes
         -----
@@ -633,6 +636,11 @@ class ToolAccessor:
             for key, layer in additional_layers.items():
                 # checking that the additional layer is present in the object
                 assert layer in self._obj, f"Layer {layer} not found in the object."
+                # checking that layer has the same shape as the expression matrix
+                assert self._obj[layer].shape == expression_matrix.shape, (
+                    f"Layer {layer} has shape {self._obj[layer].shape}, but AnnData layers must match "
+                    f"the shape of the expression matrix {expression_matrix.shape}."
+                )
                 adata.layers[key] = self._obj[layer].values
         adata.var_names = self._obj.coords[Dims.CHANNELS].values
 
@@ -661,9 +669,21 @@ class ToolAccessor:
                 adata.obs[Features.Y] = adata.obs[Features.Y].astype(float)
                 adata.obsm["spatial"] = np.array(adata.obs[[Features.X, Features.Y]])
 
+        if additional_obsm:
+            for key, layer in additional_obsm.items():
+                # checking that the additional obsm source layer is present in the object
+                assert layer in self._obj, f"Layer {layer} not found in the object."
+                # checking that the additional obsm layer has the same number of observations as the expression matrix
+                assert self._obj[layer].shape[0] == expression_matrix.shape[0], (
+                    f"Layer {layer} has {self._obj[layer].shape[0]} observations, but the expression "
+                    f"matrix has {expression_matrix.shape[0]} observations. AnnData obsm entries must match "
+                    "the number of observations in the expression matrix."
+                )
+                adata.obsm[key] = self._obj[layer].values
+
         if additional_uns:
             for key, layer in additional_uns.items():
-                # checking that the additional layer is present in the object
+                # checking that the additional uns source layer is present in the object
                 assert layer in self._obj, f"Layer {layer} not found in the object."
                 adata.uns[key] = self._obj.pp.get_layer_as_df(layer)
 

--- a/tests/pp/test_add_layer.py
+++ b/tests/pp/test_add_layer.py
@@ -34,7 +34,7 @@ def test_add_layer_wrong_dims(ds_image):
 
     with pytest.raises(
         AssertionError,
-        match="The array to add mask must 2 or 3-dimensional.",
+        match="The array to add mask must be 2- or 3-dimensional.",
     ):
         ds_image.pp.add_layer(labels, key_added=Layers.MASK)
 
@@ -45,7 +45,7 @@ def test_add_layer_wrong_shape(ds_image):
 
     with pytest.raises(
         AssertionError,
-        match="The shape of array does not match that of the image.",
+        match="The shape of the array does not match that of the image.",
     ):
         ds_image.pp.add_layer(labels, key_added=Layers.MASK)
 

--- a/tests/tl/test_convert_to_anndata.py
+++ b/tests/tl/test_convert_to_anndata.py
@@ -1,14 +1,21 @@
-def test_convert_to_spatialdata_image(ds_image):
+import numpy as np
+import pytest
+import xarray as xr
+
+from spatialproteomics.constants import Dims
+
+
+def test_convert_to_anndata_image(ds_image):
     adata = ds_image.tl.convert_to_anndata()
     assert adata.X is None
 
 
-def test_convert_to_spatialdata_segmentation(ds_segmentation):
+def test_convert_to_anndata_segmentation(ds_segmentation):
     adata = ds_segmentation.tl.convert_to_anndata()
     assert adata.X is None
 
 
-def test_convert_to_spatialdata_labels(ds_labels):
+def test_convert_to_anndata_labels(ds_labels):
     adata = ds_labels.tl.convert_to_anndata()
     assert adata.X.shape == (56, 5)
     assert "CD4_binarized" in adata.obs.columns
@@ -20,7 +27,7 @@ def test_convert_to_spatialdata_labels(ds_labels):
     assert "spatial" in adata.obsm.keys()
 
 
-def test_convert_to_spatialdata_neighborhoods(ds_neighborhoods):
+def test_convert_to_anndata_neighborhoods(ds_neighborhoods):
     adata = ds_neighborhoods.tl.convert_to_anndata()
     assert adata.X.shape == (56, 5)
     assert "_neighborhoods" in adata.obs.columns
@@ -31,3 +38,47 @@ def test_convert_to_spatialdata_neighborhoods(ds_neighborhoods):
     assert "centroid-1" in adata.obs.columns
     assert "_labels_colors" in adata.uns.keys()
     assert "spatial" in adata.obsm.keys()
+
+
+def test_convert_to_anndata_additional_obsm(ds_labels):
+    # make a copy to avoid carrying modifications of the original into other tests where they cause issues
+    ds = ds_labels.copy()
+
+    # create and add new embedding layer
+    ds["_embeddings"] = xr.DataArray(
+        np.ones((ds.sizes[Dims.CELLS], 3)),
+        dims=(Dims.CELLS, "embedding_dim"),
+        coords={
+            Dims.CELLS: ds.coords[Dims.CELLS],
+            "embedding_dim": ["embedding_1", "embedding_2", "embedding_3"],
+        },
+        name="_embeddings",
+    )
+
+    # check that trying to pass as layer errors
+    with pytest.raises(AssertionError, match="AnnData layers must match"):
+        ds.tl.convert_to_anndata(additional_layers={"embeddings": "_embeddings"})
+
+    # check that passing as obsm behaves as expected
+    adata = ds.tl.convert_to_anndata(additional_obsm={"embeddings": "_embeddings"})
+    assert "embeddings" in adata.obsm.keys()
+    assert adata.obsm["embeddings"].shape == (ds.sizes[Dims.CELLS], 3)
+    np.testing.assert_array_equal(adata.obsm["embeddings"], ds["_embeddings"].values)
+
+
+def test_convert_to_anndata_additional_obsm_wrong_shape(ds_labels):
+    ds = ds_labels.copy()
+
+    # check that trying to pass obsm with wrong number of observations errors
+    ds["_marker_embeddings"] = xr.DataArray(
+        np.ones((ds.sizes[Dims.CHANNELS], 2)),
+        dims=(Dims.CHANNELS, "marker_embedding_dim"),
+        coords={
+            Dims.CHANNELS: ds.coords[Dims.CHANNELS],
+            "marker_embedding_dim": ["marker_embedding_1", "marker_embedding_2"],
+        },
+        name="_marker_embeddings",
+    )
+
+    with pytest.raises(AssertionError, match="AnnData obsm entries must match"):
+        ds.tl.convert_to_anndata(additional_obsm={"marker_embeddings": "_marker_embeddings"})


### PR DESCRIPTION
Add support for exporting additional spatialproteomics layers to `AnnData.obsm` by passing them as `additional_obsm` in `convert_to_anndata(additional_obsm=...)`.

Additional changes:
- checks that `additional_layers` passed to `convert_to_anndata` match the shape of `AnnData.X`
- added tests for valid `obsm` export and invalid layer/obsm shapes
- fixed two tiny typos in error messages
- removed duplicated dataset initialisation in `load_image_data`